### PR TITLE
actually compute the dask array

### DIFF
--- a/benchmarks/hdf5.py
+++ b/benchmarks/hdf5.py
@@ -52,7 +52,7 @@ class DaskChunkedReduce(SingleHDF5File):
         self.da = da.from_array(self.ds, chunks=chunksize)
 
     def time_sum(self, chunksize):
-        return self.da.sum()
+        return self.da.sum().compute()
 
     def teardown(self, chunksize):
         self.f.close()


### PR DESCRIPTION
I just noticed that my benchmark was silly because I wasn't actually `compute()`ing anything.