### PR TITLE
IORaw updates & test config yaml

### DIFF
--- a/asv.conf.json
+++ b/asv.conf.json
@@ -67,6 +67,7 @@
 	"h5py": [""],
 	"h5netcdf": [""],
 	"netcdf4": [""],
+    "pyyaml": [""],
 	"rasterio": [""],
 	"xarray": [""],
     "zarr": [""],

--- a/benchmarks/__init__.py
+++ b/benchmarks/__init__.py
@@ -2,7 +2,8 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 import itertools
-
+import yaml
+import os
 import numpy as np
 
 _counter = itertools.count()
@@ -47,3 +48,18 @@ def randint(low, high=None, size=None, frac_minus=None, seed=0):
         x.flat[inds] = -1
 
     return x
+
+def getTestConfigValue(k):
+    val = None
+    # check to see if we have an environment override
+    if k.upper() in os.environ:
+        val = os.environ[k.upper()]
+    else:
+        cwd = os.getenv("PWD")  # not the same as os.getcwd()
+        config_file_path = os.path.join(cwd, "test.conf.yaml")
+        with open(config_file_path, "r") as f:
+            cfg = yaml.load(f)
+        if k in cfg:
+            val = cfg[k]
+    return val
+     

--- a/benchmarks/target_hdf5.py
+++ b/benchmarks/target_hdf5.py
@@ -1,8 +1,6 @@
 """"
    Set up HDF5 Datasets on various backends
 
-
-
 """
 
 import os
@@ -10,7 +8,12 @@ import tempfile
 import itertools
 import shutil
 import numpy as np
+import warnings
+with warnings.catch_warnings():
+    warnings.filterwarnings("ignore",category=FutureWarning)
+    import h5py
 import h5py
+from . import getTestConfigValue
 
 _counter = itertools.count()
 _DATASET_NAME = "default"
@@ -20,26 +23,34 @@ class SingleHDF5POSIXFile(object):
     """
     Single HDF5 POSIX File     
 
-    """       
+    """
+    def __init__(self):
+        self.temp_dir = None
+        self.path = None
+
     def create_objects(self, empty=True):
-       
+        
         suffix = '.h5'
         self.temp_dir = tempfile.mkdtemp()
         self.path = os.path.join(self.temp_dir,
                                  'temp-%s%s' % (next(_counter), suffix))
-        self.h5file = h5py.File(self.path, 'w')
-
+        h5file = h5py.File(self.path, 'w')
+        
+        self.nz = getTestConfigValue("num_slices")
+        
+        self.ny = 256
+        self.nx = 512
+        self.shape = (self.nz, self.ny, self.nx)
+        self.dtype = 'f8'
         if not empty:
-            self.nz = 1024
-            self.ny = 256
-            self.nx = 512
-            self.shape = (self.nz, self.ny, self.nx)
-            self.dtype = 'f8'
-            data = np.random.rand(*self.shape).astype(self.dtype)
-            self.h5file.create_dataset(_DATASET_NAME, data=data)
-            # are these both necessary
-            self.h5file.flush()
-            self.h5file.close()
+            data = np.random.rand(*self.shape)  #.astype(self.dtype)
+            h5file.create_dataset(_DATASET_NAME, data=data)
+        else:
+            h5file.create_dataset(_DATASET_NAME, self.shape, dtype=self.dtype)
+        self.dset_name = _DATASET_NAME
+        
+        h5file.close()
 
     def rm_objects(self):
-        shutil.rmtree(self.temp_dir)
+        if self.temp_dir:
+            shutil.rmtree(self.temp_dir)

--- a/benchmarks/target_hsds.py
+++ b/benchmarks/target_hsds.py
@@ -7,54 +7,60 @@ import itertools
 import numpy as np
 import h5pyd
 import time
+from . import getTestConfigValue
 
 _counter = itertools.count()
 _DATASET_NAME = "default"
- 
-     
+      
 
 class SingleHDF5HSDSFile(object):
     """
     Single HSDS File (domain)  
 
-    Note: Test expects that the following environment variables are defined:
-    * HS_USERNAME - HSDS username that test will run under
-    * HS_PASSWORD - HSDS password for given username
-    * HS_ENDPOINT - HSDS http endpoint
+    Note: Test expects that the following config settings are defined:
+    * hs_username - HSDS username that test will run under
+    * hs_password - HSDS password for given username
+    * hs_endpoint - HSDS http endpoint
 
     In addition the asvtest folder needs to have been created.  
     This can be done with the hstouch tool:
        $hstouch /home/${HS_USERNAME}/asvtest/
 
-    """       
-    def create_objects(self, empty=True):
-        suffix = '.h5'
-        # HS_USERNAME (HSDS user accont name) environment is required
-        home_folder = os.path.join("/home", os.getenv("HS_USERNAME"))  
-        self.temp_dir = os.path.join(home_folder, "asvtest/")   
-        self.path = os.path.join(self.temp_dir,
+    """   
+    def __init__(self):
+        self.username = getTestConfigValue("hs_username")
+        self.password = getTestConfigValue("hs_password")
+        self.endpoint = getTestConfigValue("hs_endpoint")
+        if self.username:
+            home_folder = os.path.join("/home", self.username)  
+            self.temp_dir = os.path.join(home_folder, "asvtest/")   
+            suffix = '.h5'
+            self.path = os.path.join(self.temp_dir,
                                  'temp-%s%s' % (next(_counter), suffix))
-        self.h5file = h5pyd.File(self.path, 'w')
 
-        if not empty:
-            self.nz = 1024
-            self.ny = 256
-            self.nx = 512
-            self.shape = (self.nz, self.ny, self.nx)
-            self.dtype = 'f8'
-            # Create a 1GB dataset
-            data = np.random.rand(*self.shape).astype(self.dtype)
-            # self.h5file.create_dataset(_DATASET_NAME, data=data)  # this fails because it's trying to write too much data at once
-            dset = self.h5file.create_dataset(_DATASET_NAME, (self.nz,self.ny,self.nx), dtype = self.dtype)
+    def create_objects(self, empty=True):   
+        self.h5file = h5pyd.File(self.path, 'w', endpoint=self.endpoint, username=self.username, password=self.password)
              
-            # Writing the entire 1GB in one h5pyd call is not yet supported, so write in slices
+        self.nz = getTestConfigValue("num_slices")
+        self.ny = 256
+        self.nx = 512
+        self.shape = (self.nz, self.ny, self.nx)
+        self.dtype = 'f8'
+        # Create a 1GB dataset
+        data = np.random.rand(*self.shape).astype(self.dtype)
+        dset = self.h5file.create_dataset(_DATASET_NAME, (self.nz,self.ny,self.nx), dtype = self.dtype)
+        self.dset_name = _DATASET_NAME
+        # Writing the entire dataset in one h5pyd call is not yet supported for large datasets, so write in slices
+        if not empty:
             for i in range(self.nz):
                 dset[i, :, :] = data[i, :, :]
 
-            self.h5file.close()
+        self.h5file.close()
 
     def rm_objects(self):
-        folder = h5pyd.Folder(self.temp_dir, mode='a')
+        if not self.username or not self.password or not self.endpoint:
+            return
+        folder = h5pyd.Folder(self.temp_dir, mode='a', endpoint=self.endpoint, username=self.username, password=self.password)
         if len(folder) == 0:
             time.sleep(10)  # allow time for HSDS to sync to S3
         for name in folder:

--- a/test.conf.yaml
+++ b/test.conf.yaml
@@ -1,0 +1,4 @@
+hs_username: null  # HSDS Username account
+hs_password: null  # HSDS Password
+hs_endpoint: http://52.4.181.237:5101  # HSDS endpoint
+num_slices: 100  # number of "Z" slices for dataset creation


### PR DESCRIPTION
I've updated the IO_raw for tests with target_hdf5 & target_hsds backends.
Creates a test.conf.yaml to store configuration related to the actual test cases.

The test.conf.yaml can be used to turn on/off individual tests.
Here's an example run with the hs_username/hs_password set in the yaml:

```[  0.00%] · For pangeo-storage-benchmarks commit hash ac4076f3:
[  0.00%] ·· Building for conda-py3.6-dask-distributed-gcsfs-h5netcdf-h5py-netcdf4-numpy-pip+h5pyd-pyyaml-rasterio-xarray-zarr.
[  0.00%] ·· Benchmarking conda-py3.6-dask-distributed-gcsfs-h5netcdf-h5py-netcdf4-numpy-pip+h5pyd-pyyaml-rasterio-xarray-zarr
[  7.14%] ··· Running IO_dask.ComputeSum_h5netcdf_POSIX_local.time_sum                                                                                              85.0±0.7ms;...
[ 14.29%] ··· Running IO_raw.IORead_h5netcdf_HSDS.time_fancycalculation                                                                                                      102ns
[ 21.43%] ··· Running IO_raw.IORead_h5netcdf_HSDS.time_readtest                                                                                                              643ms
[ 28.57%] ··· Running IO_raw.IORead_h5netcdf_POSIX_local.time_fancycalculation                                                                                             104±1ns
[ 35.71%] ··· Running IO_raw.IORead_h5netcdf_POSIX_local.time_readtest                                                                                                  45.6±0.7ms
[ 42.86%] ··· Running IO_raw.IOWrite_h5netcdf_HSDS.time_writetest                                                                                                            591ms
[ 50.00%] ··· Running IO_raw.IOWrite_h5netcdf_POSIX_local.time_writetest                                                                                                  87.3±2ms
[ 57.14%] ··· Running IO_xarray.ComputeZarrGCS.time_computemean                                                                                                             failed
[ 64.29%] ··· Running IO_xarray.ComputeZarrPOSIXLocal.time_computemean                                                                                                      6.50ms
[ 71.43%] ··· Running IO_xarray.IOReadZarrGCS.time_SyntheticRead                                                                                                            failed
[ 78.57%] ··· Running IO_xarray.IOReadZarrGCS_FUSE.time_SyntheticRead                                                                                                        207ms
[ 85.71%] ··· Running IO_xarray.IOReadZarrPOSIXLocal.time_SyntheticRead                                                                                                      196ms
[ 92.86%] ··· Running IO_xarray.IOWriteZarrGCS.time_SyntheticWrite                                                                                                          failed
[100.00%] ··· Running IO_xarray.IOWriteZarrPOSIXLocal.time_SyntheticWrite
```

And a run with the default null for username and password:

```[  0.00%] · For pangeo-storage-benchmarks commit hash ac4076f3:
[  0.00%] ·· Building for conda-py3.6-dask-distributed-gcsfs-h5netcdf-h5py-netcdf4-numpy-pip+h5pyd-pyyaml-rasterio-xarray-zarr.
[  0.00%] ·· Benchmarking conda-py3.6-dask-distributed-gcsfs-h5netcdf-h5py-netcdf4-numpy-pip+h5pyd-pyyaml-rasterio-xarray-zarr
[  7.14%] ··· Running IO_dask.ComputeSum_h5netcdf_POSIX_local.time_sum                                                                                              87.7±0.5ms;...
[ 14.29%] ··· Running IO_raw.IORead_h5netcdf_HSDS.time_fancycalculation                                                                                                        n/a
[ 21.43%] ··· Running IO_raw.IORead_h5netcdf_HSDS.time_readtest                                                                                                                n/a
[ 28.57%] ··· Running IO_raw.IORead_h5netcdf_POSIX_local.time_fancycalculation                                                                                            96.3±1ns
[ 35.71%] ··· Running IO_raw.IORead_h5netcdf_POSIX_local.time_readtest                                                                                                  45.7±0.9ms
[ 42.86%] ··· Running IO_raw.IOWrite_h5netcdf_HSDS.time_writetest                                                                                                              n/a
[ 50.00%] ··· Running IO_raw.IOWrite_h5netcdf_POSIX_local.time_writetest                                                                                                86.3±0.9ms
[ 57.14%] ··· Running IO_xarray.ComputeZarrGCS.time_computemean                                                                                                             failed
[ 64.29%] ··· Running IO_xarray.ComputeZarrPOSIXLocal.time_computemean                                                                                                      6.49ms
[ 71.43%] ··· Running IO_xarray.IOReadZarrGCS.time_SyntheticRead                                                                                                            failed
[ 78.57%] ··· Running IO_xarray.IOReadZarrGCS_FUSE.time_SyntheticRead                                                                                                        212ms
[ 85.71%] ··· Running IO_xarray.IOReadZarrPOSIXLocal.time_SyntheticRead                                                                                                      205ms
[ 92.86%] ··· Running IO_xarray.IOWriteZarrGCS.time_SyntheticWrite                                                                                                          failed
[100.00%] ··· Running IO_xarray.IOWriteZarrPOSIXLocal.time_SyntheticWrite                                                                                                    192ms
```

Note that the hsds tests now show "n/a" for results.  

I'd suggest updating the zarr benchmarks similarly.  Put "GCS_Bucket" and such in a config, so that it can be easily disabled when running in environments without access to GCS.
