### PR TITLE
Dask Stability and Pod Cleanup

### DIFF
--- a/asv.conf.json
+++ b/asv.conf.json
@@ -119,7 +119,7 @@
 
     // The directory (relative to the current directory) that raw benchmark
     // results are stored in.  If not provided, defaults to "results".
-    "results_dir": "results",
+    "results_dir": ".results",
 
     // The directory (relative to the current directory) that the html tree
     // should be written to.  If not provided, defaults to "html".

--- a/bin/kill_daskpods.sh
+++ b/bin/kill_daskpods.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# Brute force clean up ophaned Dask pods 
+#
+platform=`uname`
+OPTIND=1
+USER=$JUPYTERHUB_USER
+
+if [[ "$platform" == 'Linux' ]]; then
+    KUBECTL='/usr/bin/kubectl'
+    user=$USER
+elif [[ "$platform" == 'Darwin' ]]; then
+    KUBECTL='/usr/local/bin/kubectl'
+    user=`id -u`
+fi
+
+for pod in $($KUBECTL get po -a | grep dask-${USER}.*Completed | awk '{print $1}')
+do
+	$KUBECTL delete pod $pod 
+done
+
+


### PR DESCRIPTION
- Created routine to cleanup completed Dask pods. Previously, runs would litter Kubernetes with completed pods that do nothing. This didn't seem to effect provisioning new nodes.
- Added retries to Dask read tests.
- Reverted to using .results directory which is not tracked in Git to avoid contaminating log.
